### PR TITLE
Chapter 7 exercises

### DIFF
--- a/src/main/scala/nl/hugo/redbook/ch7/Actor.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Actor.scala
@@ -1,7 +1,7 @@
 package nl.hugo.redbook.ch7
 
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-import java.util.concurrent.{Callable,ExecutorService}
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
+import java.util.concurrent.{ Callable, ExecutorService }
 import annotation.tailrec
 
 /*
@@ -15,8 +15,7 @@ import annotation.tailrec
  * https://github.com/scalaz/scalaz/blob/scalaz-seven/etc/LICENCE
  */
 
-/**
-  * Processes messages of type `A`, one at a time. Messages are submitted to
+/** Processes messages of type `A`, one at a time. Messages are submitted to
   * the actor with the method `!`. Processing is typically performed asynchronously,
   * this is controlled by the provided `strategy`.
   *
@@ -36,7 +35,7 @@ import annotation.tailrec
   * @param strategy Execution strategy, for example, a strategy that is backed by an `ExecutorService`
   * @tparam A       The type of messages accepted by this actor.
   */
-final class Actor[A](strategy: Strategy)(handler: A => Unit, onError: Throwable => Unit = throw(_)) {
+final class Actor[A](strategy: Strategy)(handler: A => Unit, onError: Throwable => Unit = throw (_)) {
   self =>
 
   private val tail = new AtomicReference(new Node[A]())
@@ -98,12 +97,11 @@ private class Node[A](var a: A = null.asInstanceOf[A]) extends AtomicReference[N
 object Actor {
 
   /** Create an `Actor` backed by the given `ExecutorService`. */
-  def apply[A](es: ExecutorService)(handler: A => Unit, onError: Throwable => Unit = throw(_)): Actor[A] =
+  def apply[A](es: ExecutorService)(handler: A => Unit, onError: Throwable => Unit = throw (_)): Actor[A] =
     new Actor(Strategy.fromExecutorService(es))(handler, onError)
 }
 
-/**
-  * Provides a function for evaluating expressions, possibly asynchronously.
+/** Provides a function for evaluating expressions, possibly asynchronously.
   * The `apply` function should typically begin evaluating its argument
   * immediately. The returned thunk can be used to block until the resulting `A`
   * is available.
@@ -114,19 +112,17 @@ trait Strategy {
 
 object Strategy {
 
-  /**
-    * We can create a `Strategy` from any `ExecutorService`. It's a little more
+  /** We can create a `Strategy` from any `ExecutorService`. It's a little more
     * convenient than submitting `Callable` objects directly.
     */
   def fromExecutorService(es: ExecutorService): Strategy = new Strategy {
     def apply[A](a: => A): () => A = {
-      val f = es.submit { new Callable[A] { def call = a} }
+      val f = es.submit { new Callable[A] { def call():A = a } }
       () => f.get
     }
   }
 
-  /**
-    * A `Strategy` which begins executing its argument immediately in the calling thread.
+  /** A `Strategy` which begins executing its argument immediately in the calling thread.
     */
   def sequential: Strategy = new Strategy {
     def apply[A](a: => A): () => A = {

--- a/src/main/scala/nl/hugo/redbook/ch7/Actor.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Actor.scala
@@ -117,7 +117,7 @@ object Strategy {
     */
   def fromExecutorService(es: ExecutorService): Strategy = new Strategy {
     def apply[A](a: => A): () => A = {
-      val f = es.submit { new Callable[A] { def call():A = a } }
+      val f = es.submit { new Callable[A] { def call(): A = a } }
       () => f.get
     }
   }

--- a/src/main/scala/nl/hugo/redbook/ch7/Actor.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Actor.scala
@@ -1,0 +1,137 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{Callable,ExecutorService}
+import annotation.tailrec
+
+/*
+ * Implementation is taken from `scalaz` library, with only minor changes. See:
+ *
+ * https://github.com/scalaz/scalaz/blob/scalaz-seven/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
+ *
+ * This code is copyright Andriy Plokhotnyuk, Runar Bjarnason, and other contributors,
+ * and is licensed using 3-clause BSD, see LICENSE file at:
+ *
+ * https://github.com/scalaz/scalaz/blob/scalaz-seven/etc/LICENCE
+ */
+
+/**
+  * Processes messages of type `A`, one at a time. Messages are submitted to
+  * the actor with the method `!`. Processing is typically performed asynchronously,
+  * this is controlled by the provided `strategy`.
+  *
+  * Memory consistency guarantee: when each message is processed by the `handler`, any memory that it
+  * mutates is guaranteed to be visible by the `handler` when it processes the next message, even if
+  * the `strategy` runs the invocations of `handler` on separate threads. This is achieved because
+  * the `Actor` reads a volatile memory location before entering its event loop, and writes to the same
+  * location before suspending.
+  *
+  * Implementation based on non-intrusive MPSC node-based queue, described by Dmitriy Vyukov:
+  * [[http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue]]
+  *
+  * @see scalaz.concurrent.Promise for a use case.
+  *
+  * @param handler  The message handler
+  * @param onError  Exception handler, called if the message handler throws any `Throwable`.
+  * @param strategy Execution strategy, for example, a strategy that is backed by an `ExecutorService`
+  * @tparam A       The type of messages accepted by this actor.
+  */
+final class Actor[A](strategy: Strategy)(handler: A => Unit, onError: Throwable => Unit = throw(_)) {
+  self =>
+
+  private val tail = new AtomicReference(new Node[A]())
+  private val suspended = new AtomicInteger(1)
+  private val head = new AtomicReference(tail.get)
+
+  /** Alias for `apply` */
+  def !(a: A) {
+    val n = new Node(a)
+    head.getAndSet(n).lazySet(n)
+    trySchedule()
+  }
+
+  /** Pass the message `a` to the mailbox of this actor */
+  def apply(a: A) {
+    this ! a
+  }
+
+  def contramap[B](f: B => A): Actor[B] =
+    new Actor[B](strategy)((b: B) => (this ! f(b)), onError)
+
+  private def trySchedule() {
+    if (suspended.compareAndSet(1, 0)) schedule()
+  }
+
+  private def schedule() {
+    strategy(act())
+  }
+
+  private def act() {
+    val t = tail.get
+    val n = batchHandle(t, 1024)
+    if (n ne t) {
+      n.a = null.asInstanceOf[A]
+      tail.lazySet(n)
+      schedule()
+    } else {
+      suspended.set(1)
+      if (n.get ne null) trySchedule()
+    }
+  }
+
+  @tailrec
+  private def batchHandle(t: Node[A], i: Int): Node[A] = {
+    val n = t.get
+    if (n ne null) {
+      try {
+        handler(n.a)
+      } catch {
+        case ex: Throwable => onError(ex)
+      }
+      if (i > 0) batchHandle(n, i - 1) else n
+    } else t
+  }
+}
+
+private class Node[A](var a: A = null.asInstanceOf[A]) extends AtomicReference[Node[A]]
+
+object Actor {
+
+  /** Create an `Actor` backed by the given `ExecutorService`. */
+  def apply[A](es: ExecutorService)(handler: A => Unit, onError: Throwable => Unit = throw(_)): Actor[A] =
+    new Actor(Strategy.fromExecutorService(es))(handler, onError)
+}
+
+/**
+  * Provides a function for evaluating expressions, possibly asynchronously.
+  * The `apply` function should typically begin evaluating its argument
+  * immediately. The returned thunk can be used to block until the resulting `A`
+  * is available.
+  */
+trait Strategy {
+  def apply[A](a: => A): () => A
+}
+
+object Strategy {
+
+  /**
+    * We can create a `Strategy` from any `ExecutorService`. It's a little more
+    * convenient than submitting `Callable` objects directly.
+    */
+  def fromExecutorService(es: ExecutorService): Strategy = new Strategy {
+    def apply[A](a: => A): () => A = {
+      val f = es.submit { new Callable[A] { def call = a} }
+      () => f.get
+    }
+  }
+
+  /**
+    * A `Strategy` which begins executing its argument immediately in the calling thread.
+    */
+  def sequential: Strategy = new Strategy {
+    def apply[A](a: => A): () => A = {
+      val r = a
+      () => r
+    }
+  }
+}

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -139,20 +139,25 @@ object Nonblocking {
     def choiceMap[K, V](p: Par[K])(ps: Map[K, Par[V]]): Par[V] =
       ???
 
+    // Exercise 7.13
     // see `Nonblocking.scala` answers file. This function is usually called something else!
     def chooser[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
       ???
 
-    def flatMap[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
+    // Exercise 7.13
+    // Note[AD]: I've swapped the arguments back to (t: Par[A], f: Par[A]) they were
+    // (f: Par[A], t: Par[A]) in the original..
+    def choiceViaChooser[A](p: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] =
       ???
 
-    def choiceViaChooser[A](p: Par[Boolean])(f: Par[A], t: Par[A]): Par[A] =
-      ???
-
+    // Exercise 7.13
     def choiceNChooser[A](p: Par[Int])(choices: List[Par[A]]): Par[A] =
       ???
 
     def join[A](p: Par[Par[A]]): Par[A] =
+      ???
+
+    def flatMap[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
       ???
 
     def joinViaFlatMap[A](a: Par[Par[A]]): Par[A] =

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -135,6 +135,7 @@ object Nonblocking {
     def choiceViaChoiceN[A](a: Par[Boolean])(ifTrue: Par[A], ifFalse: Par[A]): Par[A] =
       ???
 
+    // Exercise 7.12
     def choiceMap[K, V](p: Par[K])(ps: Map[K, Par[V]]): Par[V] =
       ???
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -1,6 +1,6 @@
 package nl.hugo.redbook.ch7
 
-import java.util.concurrent.{Callable, CountDownLatch, ExecutorService}
+import java.util.concurrent.{ Callable, CountDownLatch, ExecutorService }
 import java.util.concurrent.atomic.AtomicReference
 import language.implicitConversions
 
@@ -17,8 +17,8 @@ object Nonblocking {
     def run[A](es: ExecutorService)(p: Par[A]): A = {
       val ref = new java.util.concurrent.atomic.AtomicReference[A] // A mutable, threadsafe reference, to use for storing the result
       val latch = new CountDownLatch(1) // A latch which, when decremented, implies that `ref` has the result
-      p(es) { a => ref.set(a); latch.countDown } // Asynchronously set the result, and decrement the latch
-      latch.await // Block until the `latch.countDown` is invoked asynchronously
+      p(es) { a => ref.set(a); latch.countDown() } // Asynchronously set the result, and decrement the latch
+      latch.await() // Block until the `latch.countDown` is invoked asynchronously
       ref.get // Once we've passed the latch, we know `ref` has been set, and return its value
     }
 
@@ -41,33 +41,30 @@ object Nonblocking {
           eval(es)(a(es)(cb))
       }
 
-    /**
-      * Helper function for constructing `Par` values out of calls to non-blocking continuation-passing-style APIs.
+    /** Helper function for constructing `Par` values out of calls to non-blocking continuation-passing-style APIs.
       * This will come in handy in Chapter 13.
       */
     def async[A](f: (A => Unit) => Unit): Par[A] = es => new Future[A] {
-      def apply(k: A => Unit) = f(k)
+      def apply(k: A => Unit):Unit = f(k)
     }
 
-    /**
-      * Helper function, for evaluating an action
+    /** Helper function, for evaluating an action
       * asynchronously, using the given `ExecutorService`.
       */
     def eval(es: ExecutorService)(r: => Unit): Unit =
-      es.submit(new Callable[Unit] { def call = r })
+      es.submit(new Callable[Unit] { def call():Unit = r })
 
-
-    def map2[A,B,C](p: Par[A], p2: Par[B])(f: (A,B) => C): Par[C] =
+    def map2[A, B, C](p: Par[A], p2: Par[B])(f: (A, B) => C): Par[C] =
       es => new Future[C] {
         def apply(cb: C => Unit): Unit = {
           var ar: Option[A] = None
           var br: Option[B] = None
-          val combiner = Actor[Either[A,B]](es) {
+          val combiner = Actor[Either[A, B]](es) {
             case Left(a) =>
-              if (br.isDefined) eval(es)(cb(f(a,br.get)))
+              if (br.isDefined) eval(es)(cb(f(a, br.get)))
               else ar = Some(a)
             case Right(b) =>
-              if (ar.isDefined) eval(es)(cb(f(ar.get,b)))
+              if (ar.isDefined) eval(es)(cb(f(ar.get, b)))
               else br = Some(b)
           }
           p(es)(a => combiner ! Left(a))
@@ -76,7 +73,7 @@ object Nonblocking {
       }
 
     // specialized version of `map`
-    def map[A,B](p: Par[A])(f: A => B): Par[B] =
+    def map[A, B](p: Par[A])(f: A => B): Par[B] =
       es => new Future[B] {
         def apply(cb: B => Unit): Unit =
           p(es)(a => eval(es) { cb(f(a)) })
@@ -85,7 +82,7 @@ object Nonblocking {
     def lazyUnit[A](a: => A): Par[A] =
       fork(unit(a))
 
-    def asyncF[A,B](f: A => B): A => Par[B] =
+    def asyncF[A, B](f: A => B): A => Par[B] =
       a => lazyUnit(f(a))
 
     def sequenceRight[A](as: List[Par[A]]): Par[List[A]] =
@@ -98,7 +95,7 @@ object Nonblocking {
       if (as.isEmpty) unit(Vector())
       else if (as.length == 1) map(as.head)(a => Vector(a))
       else {
-        val (l,r) = as.splitAt(as.length/2)
+        val (l, r) = as.splitAt(as.length / 2)
         map2(sequenceBalanced(l), sequenceBalanced(r))(_ ++ _)
       }
     }
@@ -136,14 +133,14 @@ object Nonblocking {
     def choiceViaChoiceN[A](a: Par[Boolean])(ifTrue: Par[A], ifFalse: Par[A]): Par[A] =
       ???
 
-    def choiceMap[K,V](p: Par[K])(ps: Map[K,Par[V]]): Par[V] =
+    def choiceMap[K, V](p: Par[K])(ps: Map[K, Par[V]]): Par[V] =
       ???
 
     // see `Nonblocking.scala` answers file. This function is usually called something else!
-    def chooser[A,B](p: Par[A])(f: A => Par[B]): Par[B] =
+    def chooser[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
       ???
 
-    def flatMap[A,B](p: Par[A])(f: A => Par[B]): Par[B] =
+    def flatMap[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
       ???
 
     def choiceViaChooser[A](p: Par[Boolean])(f: Par[A], t: Par[A]): Par[A] =
@@ -158,7 +155,7 @@ object Nonblocking {
     def joinViaFlatMap[A](a: Par[Par[A]]): Par[A] =
       ???
 
-    def flatMapViaJoin[A,B](p: Par[A])(f: A => Par[B]): Par[B] =
+    def flatMapViaJoin[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
       ???
 
     /* Gives us infix syntax for `Par`. */
@@ -167,8 +164,8 @@ object Nonblocking {
     // infix versions of `map`, `map2`
     class ParOps[A](p: Par[A]) {
       def map[B](f: A => B): Par[B] = Par.map(p)(f)
-      def map2[B,C](b: Par[B])(f: (A,B) => C): Par[C] = Par.map2(p,b)(f)
-      def zip[B](b: Par[B]): Par[(A,B)] = p.map2(b)((_,_))
+      def map2[B, C](b: Par[B])(f: (A, B) => C): Par[C] = Par.map2(p, b)(f)
+      def zip[B](b: Par[B]): Par[(A, B)] = p.map2(b)((_, _))
     }
   }
 }

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -128,8 +128,10 @@ object Nonblocking {
           }
       }
 
+    // Exercise 7.11
     def choiceN[A](p: Par[Int])(ps: List[Par[A]]): Par[A] = ???
 
+    // Exercise 7.11
     def choiceViaChoiceN[A](a: Par[Boolean])(ifTrue: Par[A], ifFalse: Par[A]): Par[A] =
       ???
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -154,15 +154,17 @@ object Nonblocking {
     def choiceNChooser[A](p: Par[Int])(choices: List[Par[A]]): Par[A] =
       ???
 
+    def flatMap[A, B](p: Par[A])(f: A => Par[B]): Par[B] = chooser(p)(f)
+
+    // Exercise 7.14
     def join[A](p: Par[Par[A]]): Par[A] =
       ???
 
-    def flatMap[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
-      ???
-
+    // Exercise 7.14
     def joinViaFlatMap[A](a: Par[Par[A]]): Par[A] =
       ???
 
+    // Exercise 7.14
     def flatMapViaJoin[A, B](p: Par[A])(f: A => Par[B]): Par[B] =
       ???
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -45,14 +45,14 @@ object Nonblocking {
       * This will come in handy in Chapter 13.
       */
     def async[A](f: (A => Unit) => Unit): Par[A] = es => new Future[A] {
-      def apply(k: A => Unit):Unit = f(k)
+      def apply(k: A => Unit): Unit = f(k)
     }
 
     /** Helper function, for evaluating an action
       * asynchronously, using the given `ExecutorService`.
       */
     def eval(es: ExecutorService)(r: => Unit): Unit =
-      es.submit(new Callable[Unit] { def call():Unit = r })
+      es.submit(new Callable[Unit] { def call(): Unit = r })
 
     def map2[A, B, C](p: Par[A], p2: Par[B])(f: (A, B) => C): Par[C] =
       es => new Future[C] {

--- a/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Nonblocking.scala
@@ -1,0 +1,174 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent.{Callable, CountDownLatch, ExecutorService}
+import java.util.concurrent.atomic.AtomicReference
+import language.implicitConversions
+
+object Nonblocking {
+
+  trait Future[+A] {
+    private[ch7] def apply(k: A => Unit): Unit
+  }
+
+  type Par[+A] = ExecutorService => Future[A]
+
+  object Par {
+
+    def run[A](es: ExecutorService)(p: Par[A]): A = {
+      val ref = new java.util.concurrent.atomic.AtomicReference[A] // A mutable, threadsafe reference, to use for storing the result
+      val latch = new CountDownLatch(1) // A latch which, when decremented, implies that `ref` has the result
+      p(es) { a => ref.set(a); latch.countDown } // Asynchronously set the result, and decrement the latch
+      latch.await // Block until the `latch.countDown` is invoked asynchronously
+      ref.get // Once we've passed the latch, we know `ref` has been set, and return its value
+    }
+
+    def unit[A](a: A): Par[A] =
+      es => new Future[A] {
+        def apply(cb: A => Unit): Unit =
+          cb(a)
+      }
+
+    /** A non-strict version of `unit` */
+    def delay[A](a: => A): Par[A] =
+      es => new Future[A] {
+        def apply(cb: A => Unit): Unit =
+          cb(a)
+      }
+
+    def fork[A](a: => Par[A]): Par[A] =
+      es => new Future[A] {
+        def apply(cb: A => Unit): Unit =
+          eval(es)(a(es)(cb))
+      }
+
+    /**
+      * Helper function for constructing `Par` values out of calls to non-blocking continuation-passing-style APIs.
+      * This will come in handy in Chapter 13.
+      */
+    def async[A](f: (A => Unit) => Unit): Par[A] = es => new Future[A] {
+      def apply(k: A => Unit) = f(k)
+    }
+
+    /**
+      * Helper function, for evaluating an action
+      * asynchronously, using the given `ExecutorService`.
+      */
+    def eval(es: ExecutorService)(r: => Unit): Unit =
+      es.submit(new Callable[Unit] { def call = r })
+
+
+    def map2[A,B,C](p: Par[A], p2: Par[B])(f: (A,B) => C): Par[C] =
+      es => new Future[C] {
+        def apply(cb: C => Unit): Unit = {
+          var ar: Option[A] = None
+          var br: Option[B] = None
+          val combiner = Actor[Either[A,B]](es) {
+            case Left(a) =>
+              if (br.isDefined) eval(es)(cb(f(a,br.get)))
+              else ar = Some(a)
+            case Right(b) =>
+              if (ar.isDefined) eval(es)(cb(f(ar.get,b)))
+              else br = Some(b)
+          }
+          p(es)(a => combiner ! Left(a))
+          p2(es)(b => combiner ! Right(b))
+        }
+      }
+
+    // specialized version of `map`
+    def map[A,B](p: Par[A])(f: A => B): Par[B] =
+      es => new Future[B] {
+        def apply(cb: B => Unit): Unit =
+          p(es)(a => eval(es) { cb(f(a)) })
+      }
+
+    def lazyUnit[A](a: => A): Par[A] =
+      fork(unit(a))
+
+    def asyncF[A,B](f: A => B): A => Par[B] =
+      a => lazyUnit(f(a))
+
+    def sequenceRight[A](as: List[Par[A]]): Par[List[A]] =
+      as match {
+        case Nil => unit(Nil)
+        case h :: t => map2(h, fork(sequence(t)))(_ :: _)
+      }
+
+    def sequenceBalanced[A](as: IndexedSeq[Par[A]]): Par[IndexedSeq[A]] = fork {
+      if (as.isEmpty) unit(Vector())
+      else if (as.length == 1) map(as.head)(a => Vector(a))
+      else {
+        val (l,r) = as.splitAt(as.length/2)
+        map2(sequenceBalanced(l), sequenceBalanced(r))(_ ++ _)
+      }
+    }
+
+    def sequence[A](as: List[Par[A]]): Par[List[A]] =
+      map(sequenceBalanced(as.toIndexedSeq))(_.toList)
+
+    // exercise answers
+
+    /*
+     * We can implement `choice` as a new primitive.
+     *
+     * `p(es)(result => ...)` for some `ExecutorService`, `es`, and
+     * some `Par`, `p`, is the idiom for running `p`, and registering
+     * a callback to be invoked when its result is available. The
+     * result will be bound to `result` in the function passed to
+     * `p(es)`.
+     *
+     * If you find this code difficult to follow, you may want to
+     * write down the type of each subexpression and follow the types
+     * through the implementation. What is the type of `p(es)`? What
+     * about `t(es)`? What about `t(es)(cb)`?
+     */
+    def choice[A](p: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] =
+      es => new Future[A] {
+        def apply(cb: A => Unit): Unit =
+          p(es) { b =>
+            if (b) eval(es) { t(es)(cb) }
+            else eval(es) { f(es)(cb) }
+          }
+      }
+
+    def choiceN[A](p: Par[Int])(ps: List[Par[A]]): Par[A] = ???
+
+    def choiceViaChoiceN[A](a: Par[Boolean])(ifTrue: Par[A], ifFalse: Par[A]): Par[A] =
+      ???
+
+    def choiceMap[K,V](p: Par[K])(ps: Map[K,Par[V]]): Par[V] =
+      ???
+
+    // see `Nonblocking.scala` answers file. This function is usually called something else!
+    def chooser[A,B](p: Par[A])(f: A => Par[B]): Par[B] =
+      ???
+
+    def flatMap[A,B](p: Par[A])(f: A => Par[B]): Par[B] =
+      ???
+
+    def choiceViaChooser[A](p: Par[Boolean])(f: Par[A], t: Par[A]): Par[A] =
+      ???
+
+    def choiceNChooser[A](p: Par[Int])(choices: List[Par[A]]): Par[A] =
+      ???
+
+    def join[A](p: Par[Par[A]]): Par[A] =
+      ???
+
+    def joinViaFlatMap[A](a: Par[Par[A]]): Par[A] =
+      ???
+
+    def flatMapViaJoin[A,B](p: Par[A])(f: A => Par[B]): Par[B] =
+      ???
+
+    /* Gives us infix syntax for `Par`. */
+    implicit def toParOps[A](p: Par[A]): ParOps[A] = new ParOps(p)
+
+    // infix versions of `map`, `map2`
+    class ParOps[A](p: Par[A]) {
+      def map[B](f: A => B): Par[B] = Par.map(p)(f)
+      def map2[B,C](b: Par[B])(f: (A,B) => C): Par[C] = Par.map2(p,b)(f)
+      def zip[B](b: Par[B]): Par[(A,B)] = p.map2(b)((_,_))
+    }
+  }
+}

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -64,6 +64,12 @@ object Par {
       if (run(es)(cond).get) t(es) // Notice we are blocking on the result of `cond`.
       else f(es)
 
+  // Exercise 7.11
+  def choiceN[A](n: Par[Int])(choices: List[Par[A]]): Par[A] = ???
+
+  // Exercise 7.11
+  def choiceViaChoiceN[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] = ???
+
   /* Gives us infix syntax for `Par`. */
   implicit def toParOps[A](p: Par[A]): ParOps[A] = new ParOps(p)
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -12,12 +12,12 @@ object Par {
 
   private case class UnitFuture[A](get: A) extends Future[A] {
     def isDone = true
-    def get(timeout: Long, units: TimeUnit) = get
+    def get(timeout: Long, units: TimeUnit):A = get
     def isCancelled = false
     def cancel(evenIfRunning: Boolean): Boolean = false
   }
 
-  def map2[A,B,C](a: Par[A], b: Par[B])(f: (A,B) => C): Par[C] = // `map2` doesn't evaluate the call to `f` in a separate logical thread, in accord with our design choice of having `fork` be the sole function in the API for controlling parallelism. We can always do `fork(map2(a,b)(f))` if we want the evaluation of `f` to occur in a separate thread.
+  def map2[A, B, C](a: Par[A], b: Par[B])(f: (A, B) => C): Par[C] = // `map2` doesn't evaluate the call to `f` in a separate logical thread, in accord with our design choice of having `fork` be the sole function in the API for controlling parallelism. We can always do `fork(map2(a,b)(f))` if we want the evaluation of `f` to occur in a separate thread.
     (es: ExecutorService) => {
       val af = a(es)
       val bf = b(es)
@@ -26,13 +26,16 @@ object Par {
 
   def fork[A](a: => Par[A]): Par[A] = // This is the simplest and most natural implementation of `fork`, but there are some problems with it--for one, the outer `Callable` will block waiting for the "inner" task to complete. Since this blocking occupies a thread in our thread pool, or whatever resource backs the `ExecutorService`, this implies that we're losing out on some potential parallelism. Essentially, we're using two threads when one should suffice. This is a symptom of a more serious problem with the implementation, and we will discuss this later in the chapter.
     es => es.submit(new Callable[A] {
-      def call = a(es).get
+      def call:A = a(es).get
     })
 
-  def map[A,B](pa: Par[A])(f: A => B): Par[B] =
-    map2(pa, unit(()))((a,_) => f(a))
+  // Exercise 7.03
+  def map2WhileRespectingContracts[A, B, C](a: Par[A], b: Par[B])(f: (A, B) => C): Par[C] = ???
 
-  def sortPar(parList: Par[List[Int]]) = map(parList)(_.sorted)
+  def map[A, B](pa: Par[A])(f: A => B): Par[B] =
+    map2(pa, unit(()))((a, _) => f(a))
+
+  def sortPar(parList: Par[List[Int]]):Par[List[Int]] = map(parList)(_.sorted)
 
   def equal[A](e: ExecutorService)(p: Par[A], p2: Par[A]): Boolean =
     p(e).get == p2(e).get
@@ -50,7 +53,6 @@ object Par {
 
   class ParOps[A](p: Par[A]) {
 
-
   }
 }
 
@@ -60,7 +62,7 @@ object Examples {
     if (ints.size <= 1)
       ints.headOption getOrElse 0 // `headOption` is a method defined on all collections in Scala. We saw this function in chapter 3.
     else {
-      val (l,r) = ints.splitAt(ints.length/2) // Divide the sequence in half using the `splitAt` function.
+      val (l, r) = ints.splitAt(ints.length / 2) // Divide the sequence in half using the `splitAt` function.
       sum(l) + sum(r) // Recursively sum both halves and add the results together.
     }
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -37,6 +37,9 @@ object Par {
   // Exercise 7.04
   def asyncF[A, B](f: A => B): A => Par[B] = ???
 
+  // Exercise 7.05
+  def sequence[A](ps: List[Par[A]]): Par[List[A]] = ???
+
   def map[A, B](pa: Par[A])(f: A => B): Par[B] =
     map2(pa, unit(()))((a, _) => f(a))
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -1,0 +1,67 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+import language.implicitConversions
+
+object Par {
+  type Par[A] = ExecutorService => Future[A]
+
+  def run[A](s: ExecutorService)(a: Par[A]): Future[A] = a(s)
+
+  def unit[A](a: A): Par[A] = (es: ExecutorService) => UnitFuture(a) // `unit` is represented as a function that returns a `UnitFuture`, which is a simple implementation of `Future` that just wraps a constant value. It doesn't use the `ExecutorService` at all. It's always done and can't be cancelled. Its `get` method simply returns the value that we gave it.
+
+  private case class UnitFuture[A](get: A) extends Future[A] {
+    def isDone = true
+    def get(timeout: Long, units: TimeUnit) = get
+    def isCancelled = false
+    def cancel(evenIfRunning: Boolean): Boolean = false
+  }
+
+  def map2[A,B,C](a: Par[A], b: Par[B])(f: (A,B) => C): Par[C] = // `map2` doesn't evaluate the call to `f` in a separate logical thread, in accord with our design choice of having `fork` be the sole function in the API for controlling parallelism. We can always do `fork(map2(a,b)(f))` if we want the evaluation of `f` to occur in a separate thread.
+    (es: ExecutorService) => {
+      val af = a(es)
+      val bf = b(es)
+      UnitFuture(f(af.get, bf.get)) // This implementation of `map2` does _not_ respect timeouts, and eagerly waits for the returned futures. This means that even if you have passed in "forked" arguments, using this map2 on them will make them wait. It simply passes the `ExecutorService` on to both `Par` values, waits for the results of the Futures `af` and `bf`, applies `f` to them, and wraps them in a `UnitFuture`. In order to respect timeouts, we'd need a new `Future` implementation that records the amount of time spent evaluating `af`, then subtracts that time from the available time allocated for evaluating `bf`.
+    }
+
+  def fork[A](a: => Par[A]): Par[A] = // This is the simplest and most natural implementation of `fork`, but there are some problems with it--for one, the outer `Callable` will block waiting for the "inner" task to complete. Since this blocking occupies a thread in our thread pool, or whatever resource backs the `ExecutorService`, this implies that we're losing out on some potential parallelism. Essentially, we're using two threads when one should suffice. This is a symptom of a more serious problem with the implementation, and we will discuss this later in the chapter.
+    es => es.submit(new Callable[A] {
+      def call = a(es).get
+    })
+
+  def map[A,B](pa: Par[A])(f: A => B): Par[B] =
+    map2(pa, unit(()))((a,_) => f(a))
+
+  def sortPar(parList: Par[List[Int]]) = map(parList)(_.sorted)
+
+  def equal[A](e: ExecutorService)(p: Par[A], p2: Par[A]): Boolean =
+    p(e).get == p2(e).get
+
+  def delay[A](fa: => Par[A]): Par[A] =
+    es => fa(es)
+
+  def choice[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] =
+    es =>
+      if (run(es)(cond).get) t(es) // Notice we are blocking on the result of `cond`.
+      else f(es)
+
+  /* Gives us infix syntax for `Par`. */
+  implicit def toParOps[A](p: Par[A]): ParOps[A] = new ParOps(p)
+
+  class ParOps[A](p: Par[A]) {
+
+
+  }
+}
+
+object Examples {
+  import Par._
+  def sum(ints: IndexedSeq[Int]): Int = // `IndexedSeq` is a superclass of random-access sequences like `Vector` in the standard library. Unlike lists, these sequences provide an efficient `splitAt` method for dividing them into two parts at a particular index.
+    if (ints.size <= 1)
+      ints.headOption getOrElse 0 // `headOption` is a method defined on all collections in Scala. We saw this function in chapter 3.
+    else {
+      val (l,r) = ints.splitAt(ints.length/2) // Divide the sequence in half using the `splitAt` function.
+      sum(l) + sum(r) // Recursively sum both halves and add the results together.
+    }
+
+}

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -12,7 +12,7 @@ object Par {
 
   private case class UnitFuture[A](get: A) extends Future[A] {
     def isDone = true
-    def get(timeout: Long, units: TimeUnit):A = get
+    def get(timeout: Long, units: TimeUnit): A = get
     def isCancelled = false
     def cancel(evenIfRunning: Boolean): Boolean = false
   }
@@ -26,16 +26,21 @@ object Par {
 
   def fork[A](a: => Par[A]): Par[A] = // This is the simplest and most natural implementation of `fork`, but there are some problems with it--for one, the outer `Callable` will block waiting for the "inner" task to complete. Since this blocking occupies a thread in our thread pool, or whatever resource backs the `ExecutorService`, this implies that we're losing out on some potential parallelism. Essentially, we're using two threads when one should suffice. This is a symptom of a more serious problem with the implementation, and we will discuss this later in the chapter.
     es => es.submit(new Callable[A] {
-      def call:A = a(es).get
+      def call: A = a(es).get
     })
+
+  def lazyUnit[A](a: => A): Par[A] = fork(unit(a))
 
   // Exercise 7.03
   def map2WhileRespectingContracts[A, B, C](a: Par[A], b: Par[B])(f: (A, B) => C): Par[C] = ???
 
+  // Exercise 7.04
+  def asyncF[A, B](f: A => B): A => Par[B] = ???
+
   def map[A, B](pa: Par[A])(f: A => B): Par[B] =
     map2(pa, unit(()))((a, _) => f(a))
 
-  def sortPar(parList: Par[List[Int]]):Par[List[Int]] = map(parList)(_.sorted)
+  def sortPar(parList: Par[List[Int]]): Par[List[Int]] = map(parList)(_.sorted)
 
   def equal[A](e: ExecutorService)(p: Par[A], p2: Par[A]): Boolean =
     p(e).get == p2(e).get

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -70,6 +70,11 @@ object Par {
   // Exercise 7.11
   def choiceViaChoiceN[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] = ???
 
+  // Exercise 7.12
+  def choiceMap[K, V](key: Par[K])(choices: Map[K, Par[V]]): Par[V] =
+    ???
+
+
   /* Gives us infix syntax for `Par`. */
   implicit def toParOps[A](p: Par[A]): ParOps[A] = new ParOps(p)
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -82,6 +82,17 @@ object Par {
   // Exercise 7.13
   def choiceNViaChooser[A](n: Par[Int])(choices: List[Par[A]]): Par[A] = ???
 
+  def flatMap[A, B](p: Par[A])(f: A => Par[B]): Par[B] = chooser(p)(f)
+
+  // Exercise 7.14
+  def join[A](p: Par[Par[A]]): Par[A] = ???
+
+  // Exercise 7.14
+  def joinViaFlatMap[A](a: Par[Par[A]]): Par[A] = ???
+
+  // Exercise 7.14
+  def flatMapViaJoin[A, B](p: Par[A])(f: A => Par[B]): Par[B] = ???
+
   /* Gives us infix syntax for `Par`. */
   implicit def toParOps[A](p: Par[A]): ParOps[A] = new ParOps(p)
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -29,6 +29,9 @@ object Par {
       def call: A = a(es).get
     })
 
+  def map[A, B](pa: Par[A])(f: A => B): Par[B] =
+    map2(pa, unit(()))((a, _) => f(a))
+
   def lazyUnit[A](a: => A): Par[A] = fork(unit(a))
 
   // Exercise 7.03
@@ -40,8 +43,13 @@ object Par {
   // Exercise 7.05
   def sequence[A](ps: List[Par[A]]): Par[List[A]] = ???
 
-  def map[A, B](pa: Par[A])(f: A => B): Par[B] =
-    map2(pa, unit(()))((a, _) => f(a))
+  def parMap[A, B](ps: List[A])(f: A => B): Par[List[B]] = fork {
+    var fbs: List[Par[B]] = ps.map(asyncF(f))
+    sequence(fbs)
+  }
+
+  // Exercise 7.06
+  def parFilter[A](as: List[A])(f: A => Boolean): Par[List[A]] = ???
 
   def sortPar(parList: Par[List[Int]]): Par[List[Int]] = map(parList)(_.sorted)
 

--- a/src/main/scala/nl/hugo/redbook/ch7/Par.scala
+++ b/src/main/scala/nl/hugo/redbook/ch7/Par.scala
@@ -71,9 +71,16 @@ object Par {
   def choiceViaChoiceN[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] = ???
 
   // Exercise 7.12
-  def choiceMap[K, V](key: Par[K])(choices: Map[K, Par[V]]): Par[V] =
-    ???
+  def choiceMap[K, V](key: Par[K])(choices: Map[K, Par[V]]): Par[V] = ???
 
+  // Exercise 7.13
+  def chooser[A, B](pa: Par[A])(choices: A => Par[B]): Par[B] = ???
+
+  // Exercise 7.13
+  def choiceViaChooser[A](cond: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] = ???
+
+  // Exercise 7.13
+  def choiceNViaChooser[A](n: Par[Int])(choices: List[Par[A]]): Par[A] = ???
 
   /* Gives us infix syntax for `Par`. */
   implicit def toParOps[A](p: Par[A]): ParOps[A] = new ParOps(p)

--- a/src/test/scala/nl/hugo/redbook/ch7/ExecutorServiceDecorator.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/ExecutorServiceDecorator.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.{ ExecutorService, ThreadPoolExecutor }
 
 object ExecutorServiceDecorator {
 
-  implicit class ExectorServiceOps(es: ExecutorService) {
+  implicit class ExectorServiceOps(val es: ExecutorService) extends AnyVal {
     def completedTaskCount: Long =
       es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
   }

--- a/src/test/scala/nl/hugo/redbook/ch7/ExecutorServiceDecorator.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/ExecutorServiceDecorator.scala
@@ -1,0 +1,11 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent.{ ExecutorService, ThreadPoolExecutor }
+
+object ExecutorServiceDecorator {
+
+  implicit class ExectorServiceOps(es: ExecutorService) {
+    def completedTaskCount: Long =
+      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
@@ -31,7 +31,7 @@ class Test7_03 extends WordSpec with Matchers with TimeLimitedTests {
   "A result from Par.map2WhileRespectingContracts" should {
     val combinedPar = map2WhileRespectingContracts(longRunningPar("FOO"), longRunningPar("BAR"))(_ + _)
 
-    "timeout on a get" in {
+    "timeout on a get on a long running computation" in {
       val combinedFuture = Par.run(es)(combinedPar)
 
       combinedFuture.isDone should be(false)
@@ -42,6 +42,20 @@ class Test7_03 extends WordSpec with Matchers with TimeLimitedTests {
       }
       combinedFuture.isDone should be(false)
       combinedFuture.isCancelled should be(false)
+    }
+
+    "complete the computation on short running computations" in {
+      val combinedShortPars = map2WhileRespectingContracts(Par.unit("FOO"), Par.unit("BAR"))(_+_)
+
+      val combinedShortFutures = Par.run(es)(combinedShortPars)
+
+      combinedShortFutures.isDone should be(false)
+      combinedShortFutures.isCancelled should be(false)
+
+      combinedShortFutures.get(2, TimeUnit.SECONDS)
+
+      combinedShortFutures.isDone should be(true)
+      combinedShortFutures.isCancelled should be(false)
     }
 
     // This concern is an optional test, not part of the exercise. Feel free to ignore.

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
@@ -44,6 +44,7 @@ class Test7_03 extends WordSpec with Matchers with TimeLimitedTests {
       combinedFuture.isCancelled should be(false)
     }
 
+    // This concern is an optional test, not part of the exercise. Feel free to ignore.
     "interrupt the computation on cancel" in {
       val combinedFuture = Par.run(es)(combinedPar)
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
@@ -37,9 +37,10 @@ class Test7_03 extends WordSpec with Matchers with TimeLimitedTests {
       combinedFuture.isDone should be(false)
       combinedFuture.isCancelled should be(false)
 
-      combinedFuture.get(10, TimeUnit.MILLISECONDS) should be("FOOBAR")
-
-      combinedFuture.isDone should be(true)
+      intercept[TimeoutException] {
+        combinedFuture.get(10, TimeUnit.MILLISECONDS)
+      }
+      combinedFuture.isDone should be(false)
       combinedFuture.isCancelled should be(false)
     }
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
@@ -45,7 +45,7 @@ class Test7_03 extends WordSpec with Matchers with TimeLimitedTests {
     }
 
     "complete the computation on short running computations" in {
-      val combinedShortPars = map2WhileRespectingContracts(Par.unit("FOO"), Par.unit("BAR"))(_+_)
+      val combinedShortPars = map2WhileRespectingContracts(Par.unit("FOO"), Par.unit("BAR"))(_ + _)
 
       val combinedShortFutures = Par.run(es)(combinedShortPars)
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_03.scala
@@ -1,0 +1,58 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{ Matchers, WordSpec }
+
+import scala.language.postfixOps
+
+class Test7_03 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  val es: ExecutorService = Executors.newSingleThreadExecutor
+
+  def longRunningPar[A](v: A): Par[A] = {
+    es =>
+      val task = new Callable[A] {
+        def call(): A = {
+          TimeUnit.SECONDS.sleep(100)
+          v
+        }
+      }
+      es.submit(task)
+  }
+
+  "A result from Par.map2WhileRespectingContracts" should {
+    val combinedPar = map2WhileRespectingContracts(longRunningPar("FOO"), longRunningPar("BAR"))(_ + _)
+
+    "timeout on a get" in {
+      val combinedFuture = Par.run(es)(combinedPar)
+
+      combinedFuture.isDone should be(false)
+      combinedFuture.isCancelled should be(false)
+
+      combinedFuture.get(10, TimeUnit.MILLISECONDS) should be("FOOBAR")
+
+      combinedFuture.isDone should be(true)
+      combinedFuture.isCancelled should be(false)
+    }
+
+    "interrupt the computation on cancel" in {
+      val combinedFuture = Par.run(es)(combinedPar)
+
+      combinedFuture.isDone should be(false)
+      combinedFuture.isCancelled should be(false)
+
+      combinedFuture.cancel(true) should be(true)
+
+      combinedFuture.isDone should be(false)
+      combinedFuture.isCancelled should be(true)
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -15,7 +16,7 @@ class Test7_04 extends WordSpec with Matchers with TimeLimitedTests {
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
 
-  val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+  val es: ExecutorService = Executors.newFixedThreadPool(1)
 
   "asyncF" should {
     "evaluate a function on a separate thread" in {
@@ -25,11 +26,11 @@ class Test7_04 extends WordSpec with Matchers with TimeLimitedTests {
 
       val par: Par[Int] = af(10)
 
-      es.getCompletedTaskCount should be(0)
+      es.completedTaskCount should be(0)
 
       Par.run(es)(par).get should be(f(10))
 
-      es.getCompletedTaskCount should be(1)
+      es.completedTaskCount should be(1)
     }
   }
 }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
@@ -1,0 +1,35 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_04 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+
+  "asyncF" should {
+    "evaluate a function on a separate thread" in {
+      def f: Int => Int = i => i + 1
+
+      val af: Int => Par[Int] = asyncF(f)
+
+      val par: Par[Int] = af(10)
+
+      es.getCompletedTaskCount should be(0)
+
+      Par.run(es)(par).get should be(f(10))
+
+      es.getCompletedTaskCount should be(1)
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
@@ -30,7 +30,7 @@ class Test7_04 extends WordSpec with Matchers with TimeLimitedTests {
 
       Par.run(es)(par).get should be(f(10))
 
-      es.completedTaskCount should > 0L
+      es.completedTaskCount should be > 0L
     }
   }
 }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_04.scala
@@ -30,7 +30,7 @@ class Test7_04 extends WordSpec with Matchers with TimeLimitedTests {
 
       Par.run(es)(par).get should be(f(10))
 
-      es.completedTaskCount should be(1)
+      es.completedTaskCount should > 0L
     }
   }
 }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -15,7 +16,7 @@ class Test7_05 extends WordSpec with Matchers with TimeLimitedTests {
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
 
-  val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+  val es: ExecutorService = Executors.newFixedThreadPool(1)
 
   "Par.sequence" should {
     "transform a List[Par[A]] into Par[List[A]]" in {
@@ -25,11 +26,11 @@ class Test7_05 extends WordSpec with Matchers with TimeLimitedTests {
 
       val s: Par[List[String]] = sequence(l)
 
-      es.getCompletedTaskCount should be(0)
+      es.completedTaskCount should be(0)
 
       assert(Par.run(es)(Par.sequence(l)).get == List("First", "Second", "Third"))
 
-      es.getCompletedTaskCount should be(1)
+      es.completedTaskCount should be(1)
     }
   }
 }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
@@ -20,7 +20,7 @@ class Test7_05 extends WordSpec with Matchers with TimeLimitedTests {
 
   "Par.sequence" should {
     "transform a List[Par[A]] into Par[List[A]]" in {
-      val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+      val es: ExecutorService = Executors.newFixedThreadPool(1)
 
       val l: List[Par[String]] = List(unit("First"), lazyUnit("Second"), unit("Third"))
 
@@ -30,7 +30,7 @@ class Test7_05 extends WordSpec with Matchers with TimeLimitedTests {
 
       assert(Par.run(es)(Par.sequence(l)).get == List("First", "Second", "Third"))
 
-      es.completedTaskCount should be(1)
+      es.completedTaskCount should be > 0L
     }
   }
 }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_05.scala
@@ -1,0 +1,35 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_05 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+
+  "Par.sequence" should {
+    "transform a List[Par[A]] into Par[List[A]]" in {
+      val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+
+      val l: List[Par[String]] = List(unit("First"), lazyUnit("Second"), unit("Third"))
+
+      val s: Par[List[String]] = sequence(l)
+
+      es.getCompletedTaskCount should be(0)
+
+      assert(Par.run(es)(Par.sequence(l)).get == List("First", "Second", "Third"))
+
+      es.getCompletedTaskCount should be(1)
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_06.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_06.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_06.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_06.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -15,7 +16,7 @@ class Test7_06 extends WordSpec with Matchers with TimeLimitedTests {
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
 
-  val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+  val es: ExecutorService = Executors.newCachedThreadPool
 
   "Par.parFilter" should {
     "remove items" in {
@@ -25,11 +26,11 @@ class Test7_06 extends WordSpec with Matchers with TimeLimitedTests {
 
       val fl: Par[List[Int]] = parFilter(l)(isEven)
 
-      es.getCompletedTaskCount should be(0)
+      es.completedTaskCount should be(0)
 
       Par.run(es)(fl).get should be(List(0, 2, 4))
 
-      es.getCompletedTaskCount should be > 0L
+      es.completedTaskCount should be > 0L
     }
   }
 }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_06.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_06.scala
@@ -1,0 +1,35 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_06 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+  "Par.parFilter" should {
+    "remove items" in {
+      val l: List[Int] = List(0, 1, 2, 3, 4, 5)
+
+      def isEven(i: Int): Boolean = i % 2 == 0
+
+      val fl: Par[List[Int]] = parFilter(l)(isEven)
+
+      es.getCompletedTaskCount should be(0)
+
+      Par.run(es)(fl).get should be(List(0, 2, 4))
+
+      es.getCompletedTaskCount should be > 0L
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
@@ -15,12 +15,12 @@ class Test7_11 extends WordSpec with Matchers with TimeLimitedTests {
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
 
-  val candidates: List[String] = List("First", "Second", "third")
-
-  val lazyCandidates: List[Par[String]] = candidates.map(lazyUnit(_))
-
   "Par.choiceN" should {
     "select the correct element" in {
+      val candidates: List[String] = List("First", "Second", "third")
+
+      val lazyCandidates: List[Par[String]] = candidates.map(lazyUnit(_))
+
       for (index <- candidates.indices) {
         val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -22,17 +23,17 @@ class Test7_11 extends WordSpec with Matchers with TimeLimitedTests {
       val lazyCandidates: List[Par[String]] = candidates.map(lazyUnit(_))
 
       for (index <- candidates.indices) {
-        val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+        val es: ExecutorService = Executors.newCachedThreadPool
 
         val selector: Par[Int] = lazyUnit(index)
 
         val candidate: Par[String] = choiceN(selector)(lazyCandidates)
 
-        es.getCompletedTaskCount should be(0)
+        es.completedTaskCount should be(0)
 
         Par.run(es)(candidate).get should be(candidates(index))
 
-        es.getCompletedTaskCount should be > 0L
+        es.completedTaskCount should be > 0L
       }
     }
   }
@@ -44,17 +45,17 @@ class Test7_11 extends WordSpec with Matchers with TimeLimitedTests {
     "select the correct element element" in {
       Map(true -> "First", false -> "Second").foreach {
         case (input, reference) =>
-          val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+          val es: ExecutorService = Executors.newCachedThreadPool
 
           val selector: Par[Boolean] = lazyUnit(input)
 
           val candidate: Par[String] = choiceViaChoiceN(selector)(firstChoice, secondChoice)
 
-          es.getCompletedTaskCount should be(0)
+          es.completedTaskCount should be(0)
 
           Par.run(es)(candidate).get should be(reference)
 
-          es.getCompletedTaskCount should be > 0L
+          es.completedTaskCount should be > 0L
       }
     }
   }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11.scala
@@ -1,0 +1,61 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_11 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  val candidates: List[String] = List("First", "Second", "third")
+
+  val lazyCandidates: List[Par[String]] = candidates.map(lazyUnit(_))
+
+  "Par.choiceN" should {
+    "select the correct element" in {
+      for (index <- candidates.indices) {
+        val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+        val selector: Par[Int] = lazyUnit(index)
+
+        val candidate: Par[String] = choiceN(selector)(lazyCandidates)
+
+        es.getCompletedTaskCount should be(0)
+
+        Par.run(es)(candidate).get should be(candidates(index))
+
+        es.getCompletedTaskCount should be > 0L
+      }
+    }
+  }
+
+  "Par.choiceViaChooseN" should {
+    val firstChoice = lazyUnit("First")
+    val secondChoice = lazyUnit("Second")
+
+    "select the correct element element" in {
+      Map(true -> "First", false -> "Second").foreach {
+        case (input, reference) =>
+          val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+          val selector: Par[Boolean] = lazyUnit(input)
+
+          val candidate: Par[String] = choiceViaChoiceN(selector)(firstChoice, secondChoice)
+
+          es.getCompletedTaskCount should be(0)
+
+          Par.run(es)(candidate).get should be(reference)
+
+          es.getCompletedTaskCount should be > 0L
+      }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11_NonBlocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11_NonBlocking.scala
@@ -1,0 +1,60 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Nonblocking.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_11_NonBlocking extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  "Par.choiceN" should {
+    "select the correct element" in {
+      val candidates: List[String] = List("First", "Second", "third")
+      val lazyCandidates: List[Nonblocking.Par[String]] = candidates.map(lazyUnit(_))
+
+      for (index <- candidates.indices) {
+        val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+
+        val selector: Nonblocking.Par[Int] = lazyUnit(index)
+
+        val candidate: Nonblocking.Par[String] = choiceN(selector)(lazyCandidates)
+
+        es.getCompletedTaskCount should be(0)
+
+        Nonblocking.Par.run(es)(candidate) should be(candidates(index))
+
+        es.getCompletedTaskCount should be > 0L
+      }
+    }
+  }
+
+  "Par.choiceViaChooseN" should {
+    "select the correct element element" in {
+      val firstChoice = lazyUnit("First")
+      val secondChoice = lazyUnit("Second")
+
+      Map( true -> "First", false -> "Second").foreach{
+        case (input, reference) =>
+          val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+
+          val selector = lazyUnit(input)
+
+          val candidate: Nonblocking.Par[String] = choiceViaChoiceN(selector)(firstChoice, secondChoice)
+
+          es.getCompletedTaskCount should be(0)
+
+          Nonblocking.Par.run(es)(candidate) should be(reference)
+
+          es.getCompletedTaskCount should be > 0L
+      }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11_Nonblocking.scala
@@ -10,7 +10,7 @@ import org.scalatest.{Matchers, WordSpec}
 
 import scala.language.postfixOps
 
-class Test7_11_NonBlocking extends WordSpec with Matchers with TimeLimitedTests {
+class Test7_11_Nonblocking extends WordSpec with Matchers with TimeLimitedTests {
 
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11_Nonblocking.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 
@@ -41,7 +41,7 @@ class Test7_11_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
       val firstChoice = lazyUnit("First")
       val secondChoice = lazyUnit("Second")
 
-      Map( true -> "First", false -> "Second").foreach{
+      Map(true -> "First", false -> "Second").foreach {
         case (input, reference) =>
           val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_11_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_11_Nonblocking.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -21,17 +22,17 @@ class Test7_11_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
       val lazyCandidates: List[Nonblocking.Par[String]] = candidates.map(lazyUnit(_))
 
       for (index <- candidates.indices) {
-        val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+        val es: ExecutorService = Executors.newFixedThreadPool(1)
 
         val selector: Nonblocking.Par[Int] = lazyUnit(index)
 
         val candidate: Nonblocking.Par[String] = choiceN(selector)(lazyCandidates)
 
-        es.getCompletedTaskCount should be(0)
+        es.completedTaskCount should be(0)
 
         Nonblocking.Par.run(es)(candidate) should be(candidates(index))
 
-        es.getCompletedTaskCount should be > 0L
+        es.completedTaskCount should be > 0L
       }
     }
   }
@@ -43,17 +44,17 @@ class Test7_11_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
 
       Map(true -> "First", false -> "Second").foreach {
         case (input, reference) =>
-          val es: ThreadPoolExecutor = Executors.newFixedThreadPool(1).asInstanceOf[ThreadPoolExecutor]
+          val es: ExecutorService = Executors.newFixedThreadPool(1)
 
           val selector = lazyUnit(input)
 
           val candidate: Nonblocking.Par[String] = choiceViaChoiceN(selector)(firstChoice, secondChoice)
 
-          es.getCompletedTaskCount should be(0)
+          es.completedTaskCount should be(0)
 
           Nonblocking.Par.run(es)(candidate) should be(reference)
 
-          es.getCompletedTaskCount should be > 0L
+          es.completedTaskCount should be > 0L
       }
     }
   }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_12.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_12.scala
@@ -1,0 +1,41 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_12 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  "choiceMap" should {
+    "select the correct value from a map" in {
+      val candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")
+
+      candidates.foreach {
+        case (index, item) =>
+          val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+          val selector: Par[String] = lazyUnit(index)
+
+          val parCandidates: Map[String, Par[String]] = candidates.mapValues(lazyUnit(_))
+
+          val candidate: Par[String] = choiceMap(selector)(parCandidates)
+
+          es.getCompletedTaskCount should be(0)
+
+          Par.run(es)(candidate).get should be(item)
+
+          es.getCompletedTaskCount should be > 0L
+
+      }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_12.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_12.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_12.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_12.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -21,7 +22,7 @@ class Test7_12 extends WordSpec with Matchers with TimeLimitedTests {
 
       candidates.foreach {
         case (index, item) =>
-          val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+          val es: ExecutorService = Executors.newCachedThreadPool
 
           val selector: Par[String] = lazyUnit(index)
 
@@ -29,11 +30,11 @@ class Test7_12 extends WordSpec with Matchers with TimeLimitedTests {
 
           val candidate: Par[String] = choiceMap(selector)(parCandidates)
 
-          es.getCompletedTaskCount should be(0)
+          es.completedTaskCount should be(0)
 
           Par.run(es)(candidate).get should be(item)
 
-          es.getCompletedTaskCount should be > 0L
+          es.completedTaskCount should be > 0L
 
       }
     }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_12_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_12_Nonblocking.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -21,7 +22,7 @@ class Test7_12_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
 
       candidates.foreach {
         case (index, item) =>
-          val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+          val es: ExecutorService = Executors.newCachedThreadPool
 
           val selector: Nonblocking.Par[String] = lazyUnit(index)
 
@@ -29,11 +30,11 @@ class Test7_12_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
 
           val candidate: Nonblocking.Par[String] = choiceMap(selector)(parCandidates)
 
-          es.getCompletedTaskCount should be(0)
+          es.completedTaskCount should be(0)
 
           Nonblocking.Par.run(es)(candidate) should be(item)
 
-          es.getCompletedTaskCount should be > 0L
+          es.completedTaskCount should be > 0L
       }
     }
   }

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_12_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_12_Nonblocking.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_12_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_12_Nonblocking.scala
@@ -1,0 +1,40 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Nonblocking.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_12_Nonblocking extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  "choiceMap" should {
+    "select the correct value from a map" in {
+      val candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")
+
+      candidates.foreach {
+        case (index, item) =>
+          val es: ThreadPoolExecutor = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+          val selector: Nonblocking.Par[String] = lazyUnit(index)
+
+          val parCandidates: Map[String, Nonblocking.Par[String]] = candidates.mapValues(lazyUnit(_))
+
+          val candidate: Nonblocking.Par[String] = choiceMap(selector)(parCandidates)
+
+          es.getCompletedTaskCount should be(0)
+
+          Nonblocking.Par.run(es)(candidate) should be(item)
+
+          es.getCompletedTaskCount should be > 0L
+      }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -14,11 +15,6 @@ class Test7_13 extends WordSpec with Matchers with TimeLimitedTests {
 
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
-
-  implicit class ExectionServiceOps(es: ExecutorService) {
-    def completedTaskCount: Long =
-      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
-  }
 
   "chooser" should {
     def candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
@@ -1,0 +1,89 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_13 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  implicit class ExectionServiceOps(es: ExecutorService) {
+    def completedTaskCount: Long =
+      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
+  }
+
+  "chooser" should {
+    def candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")
+
+    candidates.foreach {
+      case (index, item) =>
+        s"select $item with $index from $candidates" in {
+          val es: ExecutorService = Executors.newCachedThreadPool
+
+          val selector: Par[String] = lazyUnit(index)
+
+          val parCandidates: Map[String, Par[String]] = candidates.mapValues(lazyUnit(_))
+
+          val candidate: Par[String] = chooser(selector)(parCandidates)
+
+          es.completedTaskCount should be(0L)
+
+          Par.run(es)(candidate).get should be(item)
+
+          es.completedTaskCount should be > 0L
+        }
+    }
+  }
+
+  "choiceViaChooser" should {
+    val firstChoice = lazyUnit("First")
+    val secondChoice = lazyUnit("Second")
+
+    Map(true -> "First", false -> "Second").foreach {
+      case (input, reference) =>
+        s"select the $reference item using $input" in {
+          val es: ExecutorService = Executors.newCachedThreadPool
+
+          val selector: Par[Boolean] = lazyUnit(input)
+
+          val candidate: Par[String] = choiceViaChooser(selector)(firstChoice, secondChoice)
+
+          es.completedTaskCount should be(0)
+
+          Par.run(es)(candidate).get should be(reference)
+
+          es.completedTaskCount should be > 0L
+        }
+    }
+  }
+
+  "choiceNViaChooser" should {
+    val candidates: List[String] = List("First", "Second", "third")
+
+    val lazyCandidates: List[Par[String]] = candidates.map(lazyUnit(_))
+
+    for (index <- candidates.indices) {
+      s"selects item $index from $candidates" in {
+        val es: ExecutorService = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+        val selector: Par[Int] = lazyUnit(index)
+
+        val candidate: Par[String] = choiceNViaChooser(selector)(lazyCandidates)
+
+        es.completedTaskCount should be(0)
+
+        Par.run(es)(candidate).get should be(candidates(index))
+
+        es.completedTaskCount should be > 0L
+      }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13.scala
@@ -68,7 +68,7 @@ class Test7_13 extends WordSpec with Matchers with TimeLimitedTests {
 
     for (index <- candidates.indices) {
       s"selects item $index from $candidates" in {
-        val es: ExecutorService = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+        val es: ExecutorService = Executors.newCachedThreadPool
 
         val selector: Par[Int] = lazyUnit(index)
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -14,11 +15,6 @@ class Test7_13_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
 
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
-
-  implicit class ExectionServiceOps(es: ExecutorService) {
-    def completedTaskCount: Long =
-      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
-  }
 
   "chooser" should {
     def candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
@@ -68,7 +68,7 @@ class Test7_13_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
 
     for (index <- candidates.indices) {
       s"selects item $index from $candidates" in {
-        val es: ExecutorService = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+        val es: ExecutorService = Executors.newCachedThreadPool
 
         val selector: Nonblocking.Par[Int] = lazyUnit(index)
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
@@ -1,0 +1,89 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Nonblocking.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_13_Nonblocking extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  implicit class ExectionServiceOps(es: ExecutorService) {
+    def completedTaskCount: Long =
+      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
+  }
+
+  "chooser" should {
+    def candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")
+
+    candidates.foreach {
+      case (index, item) =>
+        s"select $item with $index from $candidates" in {
+          val es: ExecutorService = Executors.newCachedThreadPool
+
+          val selector: Nonblocking.Par[String] = lazyUnit(index)
+
+          val parCandidates: Map[String, Nonblocking.Par[String]] = candidates.mapValues(lazyUnit(_))
+
+          val candidate: Nonblocking.Par[String] = chooser(selector)(parCandidates)
+
+          es.completedTaskCount should be(0L)
+
+          Nonblocking.Par.run(es)(candidate) should be(item)
+
+          es.completedTaskCount should be > 0L
+        }
+    }
+  }
+
+  "choiceViaChooser" should {
+    val firstChoice = lazyUnit("First")
+    val secondChoice = lazyUnit("Second")
+
+    Map(true -> "First", false -> "Second").foreach {
+      case (input, reference) =>
+        s"select the $reference item using $input" in {
+          val es: ExecutorService = Executors.newCachedThreadPool
+
+          val selector: Nonblocking.Par[Boolean] = lazyUnit(input)
+
+          val candidate: Nonblocking.Par[String] = choiceViaChooser(selector)(firstChoice, secondChoice)
+
+          es.completedTaskCount should be(0)
+
+          Nonblocking.Par.run(es)(candidate) should be(reference)
+
+          es.completedTaskCount should be > 0L
+        }
+    }
+  }
+
+  "choiceNViaChooser" should {
+    val candidates: List[String] = List("First", "Second", "third")
+
+    val lazyCandidates: List[Nonblocking.Par[String]] = candidates.map(lazyUnit(_))
+
+    for (index <- candidates.indices) {
+      s"selects item $index from $candidates" in {
+        val es: ExecutorService = Executors.newCachedThreadPool.asInstanceOf[ThreadPoolExecutor]
+
+        val selector: Nonblocking.Par[Int] = lazyUnit(index)
+
+        val candidate: Nonblocking.Par[String] = choiceNChooser(selector)(lazyCandidates)
+
+        es.completedTaskCount should be(0)
+
+        Nonblocking.Par.run(es)(candidate) should be(candidates(index))
+
+        es.completedTaskCount should be > 0L
+      }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_13_Nonblocking.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_14.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_14.scala
@@ -1,0 +1,79 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_14 extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  implicit class ExectionServiceOps(es: ExecutorService) {
+    def completedTaskCount: Long =
+      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
+  }
+
+  "join" should {
+    "transform a Par[Par[A]] to a Par[A]" in {
+      val par:Par[String] = lazyUnit("FOOBAR")
+      val nestedPar: Par[Par[String]] = lazyUnit(par)
+
+      val joinedPar:Par[String] = join(nestedPar)
+
+      val es: ExecutorService = Executors.newCachedThreadPool()
+
+      es.completedTaskCount should be(0L)
+
+      Par.run(es)(joinedPar).get should be("FOOBAR")
+
+      es.completedTaskCount should be > 1L
+    }
+  }
+
+  "joinViaFlatmap" should {
+    "transform a Par[Par[A]] to a Par[A]" in {
+      val par:Par[String] = lazyUnit("FOOBAR")
+      val nestedPar: Par[Par[String]] = lazyUnit(par)
+
+      val joinedPar:Par[String] = join(nestedPar)
+
+      val es: ExecutorService = Executors.newCachedThreadPool()
+
+      es.completedTaskCount should be(0L)
+
+      Par.run(es)(joinedPar).get should be("FOOBAR")
+
+      es.completedTaskCount should be > 1L
+    }
+  }
+
+  "flatmapViaJoin" should {
+    def candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")
+
+    candidates.foreach {
+      case (index, item) =>
+        s"select $item with $index from $candidates" in {
+          val es: ExecutorService = Executors.newCachedThreadPool
+
+          val selector: Par[String] = lazyUnit(index)
+
+          val parCandidates: Map[String, Par[String]] = candidates.mapValues(lazyUnit(_))
+
+          val candidate: Par[String] = flatMapViaJoin(selector)(parCandidates)
+
+          es.completedTaskCount should be(0L)
+
+          Par.run(es)(candidate).get should be(item)
+
+          es.completedTaskCount should be > 0L
+        }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_14.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_14.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 
@@ -22,10 +22,10 @@ class Test7_14 extends WordSpec with Matchers with TimeLimitedTests {
 
   "join" should {
     "transform a Par[Par[A]] to a Par[A]" in {
-      val par:Par[String] = lazyUnit("FOOBAR")
+      val par: Par[String] = lazyUnit("FOOBAR")
       val nestedPar: Par[Par[String]] = lazyUnit(par)
 
-      val joinedPar:Par[String] = join(nestedPar)
+      val joinedPar: Par[String] = join(nestedPar)
 
       val es: ExecutorService = Executors.newCachedThreadPool()
 
@@ -33,16 +33,16 @@ class Test7_14 extends WordSpec with Matchers with TimeLimitedTests {
 
       Par.run(es)(joinedPar).get should be("FOOBAR")
 
-      es.completedTaskCount should be > 1L
+      es.completedTaskCount should be > 0L
     }
   }
 
   "joinViaFlatmap" should {
     "transform a Par[Par[A]] to a Par[A]" in {
-      val par:Par[String] = lazyUnit("FOOBAR")
+      val par: Par[String] = lazyUnit("FOOBAR")
       val nestedPar: Par[Par[String]] = lazyUnit(par)
 
-      val joinedPar:Par[String] = join(nestedPar)
+      val joinedPar: Par[String] = join(nestedPar)
 
       val es: ExecutorService = Executors.newCachedThreadPool()
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_14.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_14.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -14,11 +15,6 @@ class Test7_14 extends WordSpec with Matchers with TimeLimitedTests {
 
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
-
-  implicit class ExectionServiceOps(es: ExecutorService) {
-    def completedTaskCount: Long =
-      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
-  }
 
   "join" should {
     "transform a Par[Par[A]] to a Par[A]" in {

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_14_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_14_Nonblocking.scala
@@ -1,0 +1,79 @@
+package nl.hugo.redbook.ch7
+
+import java.util.concurrent._
+
+import nl.hugo.redbook.ch7.Nonblocking.Par._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.language.postfixOps
+
+class Test7_14_Nonblocking extends WordSpec with Matchers with TimeLimitedTests {
+
+  // Each test automatically fails after one second.
+  val timeLimit: Span = 1 second
+
+  implicit class ExectionServiceOps(es: ExecutorService) {
+    def completedTaskCount: Long =
+      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
+  }
+
+  "join" should {
+    "transform a Par[Par[A]] to a Par[A]" in {
+      val par: Nonblocking.Par[String] = lazyUnit("FOOBAR")
+      val nestedPar: Nonblocking.Par[Nonblocking.Par[String]] = lazyUnit(par)
+
+      val joinedPar: Nonblocking.Par[String] = join(nestedPar)
+
+      val es: ExecutorService = Executors.newCachedThreadPool()
+
+      es.completedTaskCount should be(0L)
+
+      Nonblocking.Par.run(es)(joinedPar) should be("FOOBAR")
+
+      es.completedTaskCount should be > 1L
+    }
+  }
+
+  "joinViaFlatmap" should {
+    "transform a Par[Par[A]] to a Par[A]" in {
+      val par: Nonblocking.Par[String] = lazyUnit("FOOBAR")
+      val nestedPar: Nonblocking.Par[Nonblocking.Par[String]] = lazyUnit(par)
+
+      val joinedPar: Nonblocking.Par[String] = join(nestedPar)
+
+      val es: ExecutorService = Executors.newCachedThreadPool()
+
+      es.completedTaskCount should be(0L)
+
+      Nonblocking.Par.run(es)(joinedPar) should be("FOOBAR")
+
+      es.completedTaskCount should be > 1L
+    }
+  }
+
+  "flatmapViaJoin" should {
+    def candidates: Map[String, String] = Map("F" -> "First", "S" -> "Second", "T" -> "Third")
+
+    candidates.foreach {
+      case (index, item) =>
+        s"select $item with $index from $candidates" in {
+          val es: ExecutorService = Executors.newCachedThreadPool
+
+          val selector: Nonblocking.Par[String] = lazyUnit(index)
+
+          val parCandidates: Map[String, Nonblocking.Par[String]] = candidates.mapValues(lazyUnit(_))
+
+          val candidate: Nonblocking.Par[String] = flatMapViaJoin(selector)(parCandidates)
+
+          es.completedTaskCount should be(0L)
+
+          Nonblocking.Par.run(es)(candidate) should be(item)
+
+          es.completedTaskCount should be > 0L
+        }
+    }
+  }
+}

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_14_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_14_Nonblocking.scala
@@ -6,7 +6,7 @@ import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 

--- a/src/test/scala/nl/hugo/redbook/ch7/Test7_14_Nonblocking.scala
+++ b/src/test/scala/nl/hugo/redbook/ch7/Test7_14_Nonblocking.scala
@@ -2,6 +2,7 @@ package nl.hugo.redbook.ch7
 
 import java.util.concurrent._
 
+import nl.hugo.redbook.ch7.ExecutorServiceDecorator._
 import nl.hugo.redbook.ch7.Nonblocking.Par._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.Span
@@ -14,11 +15,6 @@ class Test7_14_Nonblocking extends WordSpec with Matchers with TimeLimitedTests 
 
   // Each test automatically fails after one second.
   val timeLimit: Span = 1 second
-
-  implicit class ExectionServiceOps(es: ExecutorService) {
-    def completedTaskCount: Long =
-      es.asInstanceOf[ThreadPoolExecutor].getCompletedTaskCount
-  }
 
   "join" should {
     "transform a Par[Par[A]] to a Par[A]" in {


### PR DESCRIPTION
I've made tests for the chapter 7 exercises (for those that required a technical implementation)

Exercises 11 through 14 can be solved both with blocking and non-blocking methods. Therefore the non-blocking tests have been put in separate files.

I made them more verbose, added explicit types to each of the intermediate, etc.

Please let me know if you like this style. 

I can also try to combine tests with similar behavior. 

There is a method share behavior specifications through http://www.scalatest.org/user_guide/sharing_tests
which I would use do for tests professionally. However, since these tests are intended to help you with the exercises, I am hesitant to refactor out the duplication.

Do you think this will hurt readability? 

Of course, if you have any other suggestions, please let me know!


